### PR TITLE
Handle release not found issue

### DIFF
--- a/scripts/changelog-ci.py
+++ b/scripts/changelog-ci.py
@@ -76,8 +76,8 @@ class ChangelogCI:
 
         url = (
             'https://api.github.com/search/issues'
-            '?q=repo:{repo_name}'
-            '+is:pr+'
+            '?q=repo:{repo_name}+'
+            'is:pr+'
             'is:merged+'
             'sort:author-date-asc+'
             '{merged_date_filter}'


### PR DESCRIPTION
If the repository using this action does not have any previous release then the action would have thrown an error
this is a fix for that.
Now if the repository does not have any release then it will write all the previous PRs to the changelog