### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/changelog-ci.yaml
+++ b/.github/workflows/changelog-ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run Changelog CI
-        uses: saadmk11/changelog-ci@v0.7.5
+        uses: saadmk11/changelog-ci@v0.8.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/changelog-ci](https://github.com/saadmk11/changelog-ci)** published a new release [v0.8.0](https://github.com/saadmk11/changelog-ci/releases/tag/v0.8.0) on 2021-04-12T15:28:49Z
