### PR TITLE
fixed indentation in action (readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ on:
 
   # Optionally you can use `workflow_dispatch` to run Changelog CI Manually
   workflow_dispatch:
-  inputs:
-    release_version:
-      description: 'Set Release Version'
-      required: true
+    inputs:
+      release_version:
+        description: 'Set Release Version'
+        required: true
 
 jobs:
   build:


### PR DESCRIPTION
The `inputs` section within the action (in the readme) needs to be indented to be valid, simply made that change.