### PR TITLE
Update PyYAML version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyYAML~=5.4.1
+PyYAML~=6.0.1
 requests~=2.25.1
 github-action-utils~=1.1.0


### PR DESCRIPTION
Image building fails with `PyYAML~=5.4.1`, so I've updated it to `PyYAML~=6.0.1`: https://github.com/saadmk11/changelog-ci/issues/99

~~I honestly didn't run any tests~~, but after updating I was able to run Changelog CI in my Github Action successfully.
I've run tests locally: 
![Screenshot 2023-07-19 at 17 08 29](https://github.com/saadmk11/changelog-ci/assets/9437117/bed74d6d-d1f2-4a67-9550-5b0314a636b8)
